### PR TITLE
Bump nextcloud from 24.0.6-apache to 25.0.0-apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nextcloud:24.0.6-apache
+FROM nextcloud:25.0.0-apache
 
 LABEL description="apache with nextcloud, logrotate and supervisord" \
       maintainer="merzi"


### PR DESCRIPTION
Bumps nextcloud from 24.0.6-apache to 25.0.0-apache.

---
updated-dependencies:
- dependency-name: nextcloud dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>